### PR TITLE
Fix for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 `clj-yaml` is available as a Maven artifact from [Clojars](http://clojars.org/clj-yaml):
 
     :dependencies
-      [["clj-yaml" "0.3.0-SNAPSHOT"]
+      [[clj-yaml "0.4.0"]
        ...]
 
 ## Development


### PR DESCRIPTION
At least with Clojure 1.3 and Lein 1.7.1 use of "clj-yaml" as a string throws an exception:java.lang.String cannot be cast to clojure.lang.Named. Also updated the version number in the README to the latest released version.
