### PR TITLE
Use raw map key when it cannot be keywordized

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 `clj-yaml` is available as a Maven artifact from [Clojars](http://clojars.org/clj-yaml):
 
     :dependencies
-      [["clj-yaml" "0.4.0"]
+      [["clj-yaml" "0.4.1"]
        ...]
 
 ## Development

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-yaml "0.4.0"
+(defproject clj-yaml "0.4.1"
   :description "YAML encoding and decoding for Clojure using SnakeYAML"
   :url "http://github.com/lancepantz/clj-yaml"
   :dependencies

--- a/src/clj_yaml/core.clj
+++ b/src/clj_yaml/core.clj
@@ -26,7 +26,9 @@
   (decode [data]))
 
 (defn decode-key [k]
-  (if *keywordize* (keyword k) k))
+  (if *keywordize*
+   (or (keyword k) k) ; (keyword k) is nil for numbers and other values
+   k))
 
 (extend-protocol YAMLCodec
 

--- a/test/clj_yaml/core_test.clj
+++ b/test/clj_yaml/core_test.clj
@@ -58,6 +58,14 @@ the-bin: !!binary 0101")
   (let [parsed (parse-string "foo: bar")]
     (is (= "bar" (parsed :foo)))))
 
+(deftest parse-hash-with-numeric-key
+  (let [parsed (parse-string "123: 456")]
+    (is (= 456 (parsed 123)))))
+
+(deftest parse-hash-with-complex-key
+  (let [parsed (parse-string "[1, 2]: 3")]
+    (is (= 3 (parsed [1, 2])))))
+
 (deftest parse-nested-hash
   (let [parsed (parse-string nested-hash-yaml)]
     (is (= "a"   ((parsed :root) :childa)))


### PR DESCRIPTION
YAML allows the keys in a map to be arbitrary nodes: scalar, sequence
or mapping. [1]  Prior to this commit, the _keywordize_ option was
incorrectly setting map keys to `nil` for any keys that could not be
keywordized via `(keyword k)`.  For example, a valid integer key
"123: 456" would be parsed as {nil 456}, because `(keyword 123)`
evals to nil.

This commit fixes the issue by keywordizing any map key that can be
keyworded, and otherwise using the raw key if `(keyword k)` is nil.

This fixes Github lancepantz/clj-yaml issue #15. [2]

[1] http://www.yaml.org/spec/1.2/spec.html#id2764044
[2] https://github.com/lancepantz/clj-yaml/issues/15
