### PR TITLE
Fixed keywordization.

### DIFF
--- a/test/clj_yaml/core_test.clj
+++ b/test/clj_yaml/core_test.clj
@@ -109,8 +109,6 @@ the-bin: !!binary 0101")
     (is (= (Class/forName "[B") (type (:the-bin parsed))))))
 
 (deftest keywordized
-  (binding [*keywordize* false]
-    (is  (= "items" (-> hashes-lists-yaml parse-string ffirst))))
   (is  (= "items" (-> hashes-lists-yaml (parse-string false) ffirst))))
 
 (deftest not-keywordized-in-lists

--- a/test/clj_yaml/core_test.clj
+++ b/test/clj_yaml/core_test.clj
@@ -113,6 +113,9 @@ the-bin: !!binary 0101")
     (is  (= "items" (-> hashes-lists-yaml parse-string ffirst))))
   (is  (= "items" (-> hashes-lists-yaml (parse-string false) ffirst))))
 
+(deftest not-keywordized-in-lists
+  (is (every? string? (-> "[{b: c, c: d}]" (parse-string false) first keys))))
+
 (deftest dump-opts
   (let [data [{:age 33 :name "jon"} {:age 44 :name "boo"}]]
     (is (= "- age: 33\n  name: jon\n- age: 44\n  name: boo\n"


### PR DESCRIPTION
Previously `*keywordize*` was a dynamic variable, and so e.g. `(map decode ...)` would use the default `*keywordize*` (i.e. `true`) rather than the locally bound one, since `map` is the calling context. As you can imagine, this caused all kinds of flakiness when you wanted un-keywordized values anywhere but the top level in maps decoded from YAML.

I added a test case and then fixed it.
