### PR TITLE
added support for multiple YAML docs into one string

### DIFF
--- a/src/clj_yaml/core.clj
+++ b/src/clj_yaml/core.clj
@@ -54,7 +54,7 @@
   (decode [data]
     (into #{} data))
 
-  java.util.ArrayList
+  java.lang.Iterable
   (decode [data]
     (map decode data))
 
@@ -76,3 +76,10 @@
        (parse-string string)))
   ([string]
      (decode (.load (make-yaml) string))))
+
+(defn parse-all-string
+  ([string keywordize]
+     (binding [*keywordize* keywordize]
+       (parse-all-string string)))
+  ([string]
+     (decode (.loadAll (make-yaml) string))))


### PR DESCRIPTION
SnakeYAML allows to parse strings containing more than one YAML doc through the loadAll method. Added a parse-all-string function to wrap the feature for clj-yaml users.